### PR TITLE
Update hcp-configuring-oauth.adoc

### DIFF
--- a/modules/hcp-configuring-oauth.adoc
+++ b/modules/hcp-configuring-oauth.adoc
@@ -37,7 +37,7 @@ When you configure identity providers, you must configure at least one `NodePool
 +
 [source,terminal]
 ----
-$ oc edit <hosted_cluster_name> -n <hosted_cluster_namespace>
+$ oc edit hostedcluster <hosted_cluster_name> -n <hosted_cluster_namespace>
 ----
 
 . Add the OAuth configuration in the `HostedCluster` CR by using the following example:


### PR DESCRIPTION
Incorrect CLI command in documentation for editing HostedCluster custom resource.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12 + 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-62677

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
https://github.com/kchawlani19/openshift-docs/pull/1#event-20063370038

